### PR TITLE
refactor with argparse instead of env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: fix-encoding-pragma
+        args: ['--remove']
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: mixed-line-ending

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft docs
 
 include tox.ini README.rst
 
-global-exclude *~ *.py[cod] *.so
+global-exclude *~ *.py[cod]

--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,7 @@ To run all ``pre-commit`` checks manually, try::
     :target: https://github.com/sarnold/pyserv/releases
     :alt: GitHub tag
 
-.. |python| image:: https://img.shields.io/badge/python-3.6+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.7+-blue.svg
     :target: https://www.python.org/downloads/
     :alt: Python
 

--- a/README.rst
+++ b/README.rst
@@ -70,26 +70,28 @@ default configuration values with path overrides set by Tox::
 
   $ tox -e py
   ...
-  py run-test: commands[0] | python pyserv/settings.py
+  py run-test: commands[0] | python -c 'from pyserv.settings import show_uservars; print(show_uservars())'
   Python version: 3.9.7 (default, Mar 19 2022, 18:11:11)
   [GCC 11.1.0]
   -------------------------------------------------------------------------------
-  pyserv 1.2.1.dev8
-  Simple HTTP server with GET rewriting and request/header logging.
+  pyserv 1.2.2.dev3
+
+  Pyserv default settings for daemon mode.
 
   Default user vars:
-    log_dir: /home/user/.cache/pyserv/1.2.1.dev8/log
-    pid_dir: /home/user/.cache/pyserv/1.2.1.dev8
-    doc_root: /home/user/src/pyserv
+    log_dir: /home/nerdboy/.cache/pyserv/1.2.2.dev3/log
+    pid_dir: /home/nerdboy/.cache/pyserv/1.2.2.dev3/run
+    doc_dir: /home/nerdboy/src/pyserv
 
   Current environment values:
     DEBUG: 0
     PORT: 8080
     IFACE: 127.0.0.1
-    DOCROOT: /home/user/src/pyserv
-    LOGFILE: /home/user/src/pyserv/.tox/py/log/httpd.log
-    PIDFILE: /home/user/src/pyserv/.tox/py/tmp/httpd.pid
+    LOG: /home/nerdboy/src/pyserv/.tox/py/log/httpd.log
+    PID: /home/nerdboy/src/pyserv/.tox/py/tmp/httpd.pid
+    DOCROOT: /home/nerdboy/src/pyserv
   -------------------------------------------------------------------------------
+  [test output snipped]
 
 Use any of the variables under "Current environment values" to set your
 own custom environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ omit = [
 source = ["pyserv"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 85
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ omit = [
 source = ["pyserv"]
 
 [tool.coverage.report]
-fail_under = 50
+fail_under = 90
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/pyserv/__init__.py
+++ b/pyserv/__init__.py
@@ -37,7 +37,7 @@ class GetHandler(SimpleHTTPRequestHandler):
     """
 
     def do_GET(self):
-        logging.debug('Thread name: %s', threading.currentThread().getName())
+        logging.debug('Thread name: %s', threading.current_thread().name)
         logging.debug('Thread count: %s', threading.active_count())
         logging.info('Path in: %s', self.path)
         _, file_path = munge_url(self.path)

--- a/pyserv/__init__.py
+++ b/pyserv/__init__.py
@@ -1,13 +1,12 @@
-# -*- coding: utf-8 -*-
-
 """Simple HTTP server classes with GET path rewriting and request/header logging."""
 
 import logging
 import threading
+from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse
 
-from pyserv._version import __version__
+from ._version import __version__
 
 VERSION = __version__
 
@@ -65,6 +64,7 @@ class GetHandler(SimpleHTTPRequestHandler):
 class GetServer(threading.Thread):
     """
     Threaded wrapper class for custom ThreadingHTTPServer instance.
+
     Usage::
 
         s = GetServer('', 8080)
@@ -72,12 +72,14 @@ class GetServer(threading.Thread):
         s.stop()
     """
 
-    def __init__(self, iface, port):
+    def __init__(self, iface, port, directory):
         """Setup server, iface, and port"""
         super().__init__()
         self.iface = iface
         self.port = int(port)
-        self.server = ThreadingHTTPServer((self.iface, self.port), GetHandler)
+        self.directory = directory
+        self.handler = partial(GetHandler, directory=self.directory)
+        self.server = ThreadingHTTPServer((self.iface, self.port), self.handler)
 
     def run(self):
         """Start main server thread"""

--- a/pyserv/server.py
+++ b/pyserv/server.py
@@ -30,7 +30,7 @@ def serv_run(iface='', port=8080, directory='.'):  # pragma: no cover
     :param iface: server listen interface
     :param port: server listen port
     """
-    httpd = serv_init(iface, port)
+    httpd = serv_init(iface, port, directory)
     logging.info('Starting HTTP SERVER at %s:%s', iface, port)
     try:
         httpd.start()

--- a/pyserv/server.py
+++ b/pyserv/server.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Simple HTTP server with broken GET rewriting for serving FW upgrades or
 other local files in an engineering development environment.
@@ -11,7 +9,7 @@ import sys
 from . import GetServer
 
 
-def serv_init(iface, port):
+def serv_init(iface, port, directory):
     """
     Init http server for handoff; init logging and server/handler classes.
 
@@ -20,11 +18,11 @@ def serv_init(iface, port):
     :return httpd_handler: threaded httpd handle, eg, httpd.start()
     """
     logging.basicConfig(level=logging.INFO)
-    httpd_handler = GetServer(iface, port)
+    httpd_handler = GetServer(iface, port, directory)
     return httpd_handler
 
 
-def serv_run(iface='', port=8080):  # pragma: no cover
+def serv_run(iface='', port=8080, directory='.'):  # pragma: no cover
     """
     Run in foreground command wrapper for console entry point;
     init logging and server, run the server, stop the server.

--- a/pyserv/settings.py
+++ b/pyserv/settings.py
@@ -24,7 +24,7 @@ def platform_check():
 
     :return: True if POSIX, else False
     """
-    valid_os = False
+    valid_os = []
     myname = sys.platform
     is_posix = os.name == 'posix'
     posix_list = [
@@ -33,7 +33,7 @@ def platform_check():
         'openbsd',
         'freebsd',
     ]
-    valid_os = any([x for x in posix_list if x in myname and is_posix])
+    valid_os = [x for x in posix_list if x in myname and is_posix]
 
     return valid_os
 
@@ -63,7 +63,7 @@ def show_uservars():
     print("-" * 79)
 
 
-DEBUG = os.getenv('DEBUG', default=0)
+DEBUG = os.getenv('DEBUG', default='0')
 LOG = 'httpd.log'
 PID = 'httpd.pid'
 

--- a/pyserv/settings.py
+++ b/pyserv/settings.py
@@ -1,81 +1,72 @@
-# -*- coding: utf-8 -*-
 """
 Pyserv default settings for daemon mode.
 """
 import importlib
 import os
 import sys
-from pathlib import Path
 
-from appdirs import AppDirs
-
-from pyserv import VERSION as version
+from pyserv import __version__ as version
 
 
 def init_dirs(dirs):
     """
     Check and create user dirs for logs and PID (doc root is assumed
     to already exist).
-
     :param: list of Path objs
     """
     for usr_path in dirs:
         usr_path.mkdir(parents=True, exist_ok=True)
 
 
-def get_userdirs():
+def platform_check():
     """
-    Set platform-agnostic user directory paths via appdirs.
+    Check to see if we think we are POSIX.
 
-    :return tuple: logdir, cachedir, docroot as Path objs
+    :return: True if POSIX, else False
     """
-    dirs = AppDirs(appname='pyserv', version=version)
-    logdir = Path(dirs.user_log_dir)
-    cachedir = Path(dirs.user_cache_dir)
-    docroot = Path(os.getcwd())
-    return logdir, cachedir, docroot
+    valid_os = False
+    myname = sys.platform
+    is_posix = os.name == 'posix'
+    posix_list = [
+        'linux',
+        'darwin',
+        'openbsd',
+        'freebsd',
+    ]
+    valid_os = any([x for x in posix_list if x in myname and is_posix])
+
+    return valid_os
 
 
 def show_uservars():
     """
-    Display host platform user paths, files and environment.
+    Display default host paths and environment.
     """
     print("Python version:", sys.version)
     print("-" * 79)
     print(f"pyserv {version}")
 
-    dirnames = ['log_dir', 'pid_dir', 'doc_root']
     modname = 'pyserv.settings'
     try:
         mod = importlib.import_module(modname)
         print(mod.__doc__)
 
-        print("Default user vars:")
-        for dirname, path in zip(dirnames, mod.get_userdirs()):
-            print(f'  {dirname}: {path}')
+        print("Default user paths:")
+        print(f"  LOG file: {LOG}")
+        print(f"  PID file: {PID}")
 
-    except (ImportError, AttributeError) as exc:
+    except (ImportError, NameError) as exc:
         print("FAILED:", repr(exc))
 
     print("\nCurrent environment values:")
     print(f"  DEBUG: {DEBUG}")
-    print(f"  PORT: {PORT}")
-    print(f"  IFACE: {IFACE}")
-    print(f"  DOCROOT: {HOMEDIR}")
-    print(f"  LOGFILE: {LOGFILE}")
-    print(f"  PIDFILE: {PIDFILE}")
     print("-" * 79)
 
 
-DEBUG = os.getenv('DEBUG', default='0')
-PORT = os.getenv('PORT', default='8080')
-IFACE = os.getenv('IFACE', default='127.0.0.1')
-HOMEDIR = os.getenv('DOCROOT', default=str(get_userdirs()[2]))
-LOGFILE = os.getenv('LOGFILE', default=str(get_userdirs()[0].joinpath('httpd.log')))
-PIDFILE = os.getenv('PIDFILE', default=str(get_userdirs()[1].joinpath('httpd.pid')))
-LOGDIR = Path(LOGFILE).resolve().parent
-PIDDIR = Path(PIDFILE).resolve().parent
+DEBUG = os.getenv('DEBUG', default=0)
+LOG = 'httpd.log'
+PID = 'httpd.pid'
 
 # some test output
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     show_uservars()

--- a/scripts/httpdaemon
+++ b/scripts/httpdaemon
@@ -11,7 +11,7 @@ from pathlib import Path
 from daemon import Daemon
 from daemon.parent_logger import setup_logging
 
-from pyserv import GetServer
+from pyserv import GetServer, __version__
 from pyserv.settings import (
     DEBUG,
     DOCROOT,
@@ -48,17 +48,27 @@ if __name__ == "__main__":
     if not platform_check():
         raise OSError(f'Incompatible platform type "{sys.platform}"')
 
+    daemon_args = ['start', 'stop', 'restart', 'status']
     init_dirs([Path(LOG).parent, Path(PID).parent])
     setup_logging(DEBUG, Path(LOG), 'httpd')
 
-    if len(sys.argv) == 2:
-        arg = sys.argv[1]
-        if arg in ('start', 'stop', 'restart', 'status'):
-            d = servDaemon(Path(PID), home_dir=DOCROOT, verbose=0, use_cleanup=True)
-            getattr(d, arg)()
-        else:
-            print("usage: %s start|stop|restart|status" % sys.argv[0])
-            sys.exit(2)
-    else:
-        print("usage: %s start|stop|restart|status" % sys.argv[0])
-        sys.exit(2)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='Threaded HTTP server daemon',
+    )
+    parser.add_argument("--version", action="version",
+                        version=f"httpdaemon {__version__}")
+    parser.add_argument('run', choices=daemon_args, nargs=1)
+
+    args = parser.parse_args()
+
+    init_dirs([Path(LOG).parent, Path(PID).parent, Path(DOCROOT)])
+    setup_logging(DEBUG, Path(LOG), 'httpd')
+
+    d = servDaemon(
+        Path(PID),
+        home_dir=DOCROOT,
+        verbose=0,
+        use_cleanup=True
+    )
+    getattr(d, args.run[0])()

--- a/scripts/httpdaemon
+++ b/scripts/httpdaemon
@@ -1,51 +1,20 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
+import argparse
 import datetime
 import logging
 import os
 import sys
 from datetime import timezone
+from pathlib import Path
 
 from daemon import Daemon
 from daemon.parent_logger import setup_logging
 
-from pyserv.server import GetServer
-from pyserv.settings import (
-    DEBUG,
-    HOMEDIR,
-    IFACE,
-    LOGDIR,
-    LOGFILE,
-    PIDDIR,
-    PIDFILE,
-    PORT,
-    init_dirs,
-)
+from pyserv import GetServer, __version__
+from pyserv.settings import DEBUG, LOG, PID, init_dirs, platform_check
 
-user_dirs = [LOGDIR, PIDDIR]
 logger = logging.getLogger(__name__)
-timestamp = datetime.datetime.now(timezone.utc)  # use local time for console
-
-
-def platform_check():
-    """
-    Check to see if we think we are POSIX.
-
-    :return: True if POSIX, else False
-    """
-    valid_os = False
-    myname = sys.platform
-    is_posix = os.name == 'posix'
-    posix_list = [
-        'linux',
-        'darwin',
-        'openbsd',
-        'freebsd',
-    ]
-    valid_os = any([x for x in posix_list if x in myname and is_posix])
-
-    return valid_os
 
 
 class servDaemon(Daemon):
@@ -54,13 +23,8 @@ class servDaemon(Daemon):
         Daemon needs a run method. In this case we need to instantiate
         our GetServer obj here, ie, *after* the Daemon object.
         """
-        pwd = os.getcwd()
-        try:
-            os.chdir(HOMEDIR)
-            servd = GetServer(IFACE, PORT)
-            servd.start()
-        finally:
-            os.chdir(pwd)
+        servd = GetServer(IFACE, PORT, DOCROOT)
+        servd.start()
 
     def cleanup(self):
         """And we need a cleanup method."""
@@ -68,20 +32,46 @@ class servDaemon(Daemon):
 
 
 if __name__ == "__main__":
-    init_dirs(user_dirs)
-    setup_logging(DEBUG, LOGFILE, 'httpd')
-
+    """
+    Collect and process command options/arguments and init app dirs
+    if needed.
+    """
     if not platform_check():
         raise OSError(f'Incompatible platform type "{sys.platform}"')
 
-    if len(sys.argv) == 2:
-        arg = sys.argv[1]
-        if arg in ('start', 'stop', 'restart', 'status'):
-            d = servDaemon(PIDFILE, home_dir=HOMEDIR, verbose=0, use_cleanup=True)
-            getattr(d, arg)()
-        else:
-            print("usage: %s start|stop|restart|status" % sys.argv[0])
-            sys.exit(2)
-    else:
-        print("usage: %s start|stop|restart|status" % sys.argv[0])
-        sys.exit(2)
+    daemon_args = ['start', 'stop', 'restart', 'status']
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='Threaded HTTP server daemon'
+    )
+    parser.add_argument('-L', '--logfile', type=str, default=LOG,
+                        help='Log file path')
+    parser.add_argument('-P', '--pidfile', type=str, default=PID,
+                        help='PID file path')
+    parser.add_argument('-R', '--rootdir', type=str, default='.',
+                        help='Server root directory')
+    parser.add_argument('-i', '--iface', type=str, default='',
+                        help='Listen address')
+    parser.add_argument('-p', '--port', type=int, default=8080,
+                        help='Listen port')
+    parser.add_argument("--version", action="version",
+                        version=f"httpdaemon {__version__}")
+    parser.add_argument('run', choices=daemon_args, nargs=1)
+
+    args = parser.parse_args()
+
+    init_dirs([Path(args.logfile).parent, Path(args.pidfile).parent])
+    setup_logging(DEBUG, Path(args.logfile), 'httpd')
+
+    PORT = int(args.port)
+    IFACE = str(args.iface)
+    DOCROOT = str(args.rootdir)
+
+    d = servDaemon(
+        args.pidfile,
+        home_dir=DOCROOT,
+        verbose=0,
+        use_cleanup=True
+    )
+    getattr(d, args.run[0])()

--- a/scripts/httpdaemon
+++ b/scripts/httpdaemon
@@ -11,8 +11,17 @@ from pathlib import Path
 from daemon import Daemon
 from daemon.parent_logger import setup_logging
 
-from pyserv import GetServer, __version__
-from pyserv.settings import DEBUG, LOG, PID, init_dirs, platform_check
+from pyserv import GetServer
+from pyserv.settings import (
+    DEBUG,
+    DOCROOT,
+    IFACE,
+    LOG,
+    PID,
+    PORT,
+    init_dirs,
+    platform_check,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,45 +42,23 @@ class servDaemon(Daemon):
 
 if __name__ == "__main__":
     """
-    Collect and process command options/arguments and init app dirs
-    if needed.
+    Collect and process environment vars, init directories if needed,
+    setup logging. Check if platform is POSIX, then start the daemon.
     """
     if not platform_check():
         raise OSError(f'Incompatible platform type "{sys.platform}"')
 
-    daemon_args = ['start', 'stop', 'restart', 'status']
+    init_dirs([Path(LOG).parent, Path(PID).parent])
+    setup_logging(DEBUG, Path(LOG), 'httpd')
 
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description='Threaded HTTP server daemon'
-    )
-    parser.add_argument('-L', '--logfile', type=str, default=LOG,
-                        help='Log file path')
-    parser.add_argument('-P', '--pidfile', type=str, default=PID,
-                        help='PID file path')
-    parser.add_argument('-R', '--rootdir', type=str, default='.',
-                        help='Server root directory')
-    parser.add_argument('-i', '--iface', type=str, default='',
-                        help='Listen address')
-    parser.add_argument('-p', '--port', type=int, default=8080,
-                        help='Listen port')
-    parser.add_argument("--version", action="version",
-                        version=f"httpdaemon {__version__}")
-    parser.add_argument('run', choices=daemon_args, nargs=1)
-
-    args = parser.parse_args()
-
-    init_dirs([Path(args.logfile).parent, Path(args.pidfile).parent])
-    setup_logging(DEBUG, Path(args.logfile), 'httpd')
-
-    PORT = int(args.port)
-    IFACE = str(args.iface)
-    DOCROOT = str(args.rootdir)
-
-    d = servDaemon(
-        args.pidfile,
-        home_dir=DOCROOT,
-        verbose=0,
-        use_cleanup=True
-    )
-    getattr(d, args.run[0])()
+    if len(sys.argv) == 2:
+        arg = sys.argv[1]
+        if arg in ('start', 'stop', 'restart', 'status'):
+            d = servDaemon(Path(PID), home_dir=DOCROOT, verbose=0, use_cleanup=True)
+            getattr(d, arg)()
+        else:
+            print("usage: %s start|stop|restart|status" % sys.argv[0])
+            sys.exit(2)
+    else:
+        print("usage: %s start|stop|restart|status" % sys.argv[0])
+        sys.exit(2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords =
     httpd
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
     appdirs
     daemonizer @ git+https://github.com/sarnold/python-daemonizer.git ; sys_platform!='Windows'
@@ -40,6 +40,9 @@ exclude =
     examples*
     docs*
     tests*
+
+# [options.data_files]
+# bin = scripts/httpdaemon
 
 [options.entry_points]
 console_scripts =

--- a/tests/check_daemon.py
+++ b/tests/check_daemon.py
@@ -1,0 +1,23 @@
+"""
+Tiny client to make a web request to port 8080.
+"""
+
+import logging
+import os
+import time
+
+import requests
+
+iface = '0.0.0.0'
+port = 8080
+
+
+def get_request(port, iface):
+    """Test serv client"""
+    URL = f'http://{iface}:{port}/'
+    r = requests.get(URL)
+    print(f'Got request status {r.reason,} from {r.url}')
+    return r
+
+if __name__ == '__main__':
+    res = get_request(port, iface)

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,43 +1,19 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 from pathlib import Path
 
-from pyserv import VERSION
+import pytest
+
+import pyserv
 from pyserv.settings import (
-    DEBUG,
-    HOMEDIR,
-    IFACE,
-    LOGDIR,
-    LOGFILE,
-    PIDDIR,
-    PIDFILE,
-    PORT,
-    get_userdirs,
     init_dirs,
+    platform_check,
     show_uservars,
+    version,
 )
 
 WIN32 = sys.platform == 'win32'
 APPLE = sys.platform == 'darwin'
-
-
-def test_get_userdirs():
-    """We should get Path objs"""
-    logdir, cachedir, docroot = get_userdirs()
-
-    for thing in logdir, cachedir, docroot:
-        assert isinstance(thing, Path)
-
-    if WIN32:
-        assert logdir.name == 'Logs'
-    elif APPLE:
-        assert logdir.name == VERSION
-    else:
-        assert logdir.name == 'log'
-
-    assert cachedir.name == VERSION
-    assert docroot.name == Path.cwd().name
 
 
 def test_init_dirs(tmp_path):
@@ -52,6 +28,18 @@ def test_init_dirs(tmp_path):
         assert thing.is_dir()
 
 
+def test_platform_check():
+    """Test for POSIX platform"""
+    iam = platform_check()
+    assert iam
+
+
 def test_show_uservars():
     """Start with default env"""
+    show_uservars()
+
+
+def test_show_uservars_error(monkeypatch):
+    """Monkeypatch attr"""
+    monkeypatch.delattr('pyserv.settings.LOG', raising=True)
     show_uservars()

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -28,6 +28,8 @@ def test_init_dirs(tmp_path):
         assert thing.is_dir()
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="daemon not supported on Windows")
 def test_platform_check():
     """Test for POSIX platform"""
     iam = platform_check()

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -6,6 +6,7 @@ import pytest
 
 import pyserv
 from pyserv.settings import (
+    get_userdirs,
     init_dirs,
     platform_check,
     show_uservars,
@@ -14,6 +15,24 @@ from pyserv.settings import (
 
 WIN32 = sys.platform == 'win32'
 APPLE = sys.platform == 'darwin'
+
+
+def test_get_userdirs():
+    """We should get Path objs"""
+    logdir, piddir, docdir = get_userdirs()
+
+    for thing in logdir, piddir, docdir:
+        assert isinstance(thing, Path)
+
+    if WIN32:
+        assert logdir.name == 'Logs'
+    elif APPLE:
+        assert logdir.name == version
+    else:
+        assert logdir.name == 'log'
+
+    assert piddir.name == 'run'
+    assert docdir.name == Path.cwd().name
 
 
 def test_init_dirs(tmp_path):

--- a/tests/test_serv.py
+++ b/tests/test_serv.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import threading
 import time
@@ -9,6 +8,7 @@ from pyserv import GetServer, munge_url
 from pyserv import settings as cfg
 from pyserv.server import *
 
+directory = '.'
 iface = '127.0.0.1'
 port = 8000
 
@@ -23,7 +23,7 @@ def get_request(port, iface):
 def test_get_server_attrs():
     """Test GetServer attrs """
 
-    serv_thread = GetServer(iface, port)
+    serv_thread = GetServer(iface, port, directory)
     assert isinstance(serv_thread, GetServer)
     assert hasattr(serv_thread, 'start')
     assert hasattr(serv_thread, 'stop')
@@ -32,7 +32,7 @@ def test_get_server_attrs():
 def test_serv_init():
     """Test serv_init wrapper"""
 
-    serv_thread = serv_init(iface, port)
+    serv_thread = serv_init(iface, port, directory)
     assert isinstance(serv_thread, GetServer)
     assert hasattr(serv_thread, 'start')
     assert hasattr(serv_thread, 'stop')

--- a/tox.ini
+++ b/tox.ini
@@ -141,7 +141,6 @@ commands =
 skip_install = true
 allowlist_externals =
     bash
-    tail
 
 setenv =
     DEBUG = {env:DEBUG:1}
@@ -160,16 +159,7 @@ deps =
 
 commands =
     pip install pyserv --force-reinstall --pre --prefer-binary -f dist/
-    python -c "from pyserv.settings import show_uservars; show_uservars()"
-    httpdaemon start -P{env:PIDFILE} -L{env:LOGFILE}
-    bash -c 'sleep 2'
-    httpdaemon status
-    python tests/check_daemon.py
-    bash -c 'sleep 1'
-    tail -n {env:TAIL} {env:LOGFILE}
-
-commands_post =
-    httpdaemon stop
+    python -c "from pyserv import server; print(server.__doc__)"
 
 [testenv:lint]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,8 @@ deps =
 skip_install = true
 
 setenv =
-    LOGFILE = {env:LOGFILE:{envlogdir}/httpd.log}
-    PIDFILE = {env:PIDFILE:{envtmpdir}/httpd.pid}
+    LOG = {env:LOG:{envlogdir}/httpd.log}
+    PID = {env:PID:{envtmpdir}/httpd.pid}
 
 passenv =
     DISPLAY
@@ -57,7 +57,7 @@ deps =
     -e .[test,cov]
 
 commands =
-    python pyserv/settings.py
+    python -c "from pyserv.settings import show_uservars; print(show_uservars())"
     pytest -v --capture=fd . --cov=pyserv --cov-branch --cov-report term-missing pyserv/
     coverage xml
     bash -c './.github/fix_pkg_name.sh'
@@ -67,8 +67,8 @@ skip_install = true
 
 setenv =
     DEBUG = {env:DEBUG:1}
-    #LOGFILE = {env:LOGFILE:{envlogdir}/httpd.log}
-    #PIDFILE = {env:PIDFILE:{envtmpdir}/httpd.pid}
+    LOG = {env:LOG:{envlogdir}/httpd.log}
+    PID = {env:PID:{envtmpdir}/httpd.pid}
     TAIL = {env:TAIL:1}
 
 passenv =
@@ -90,11 +90,11 @@ deps =
     -e .
 
 commands =
-    python pyserv/settings.py
+    python -c "from pyserv.settings import show_uservars; print(show_uservars())"
     httpdaemon start
     bash -c 'sleep 1'
     python tests/check_daemon.py
-    tail -n {env:TAIL} httpd.log
+    tail -n {env:TAIL} {env:LOG}
 
 commands_post =
     httpdaemon stop
@@ -144,9 +144,6 @@ allowlist_externals =
 
 setenv =
     DEBUG = {env:DEBUG:1}
-    LOGFILE = {env:LOGFILE:{envlogdir}/httpd.log}
-    PIDFILE = {env:PIDFILE:{envtmpdir}/httpd.pid}
-    TAIL = {env:TAIL:1}
 
 passenv =
     CI

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{6,7,8,9,10}-{linux,macos,windows}
+envlist = py3{7,8,9,10}-{linux,macos,windows}
 skip_missing_interpreters = true
 isolated_build = true
 skipsdist = true
@@ -62,6 +62,43 @@ commands =
     coverage xml
     bash -c './.github/fix_pkg_name.sh'
 
+[testenv:dev]
+skip_install = true
+
+setenv =
+    DEBUG = {env:DEBUG:1}
+    #LOGFILE = {env:LOGFILE:{envlogdir}/httpd.log}
+    #PIDFILE = {env:PIDFILE:{envtmpdir}/httpd.pid}
+    TAIL = {env:TAIL:1}
+
+passenv =
+    HOME
+    USERNAME
+    USER
+    XDG_*
+    PYTHONIOENCODING
+    PIP_DOWNLOAD_CACHE
+
+allowlist_externals =
+    bash
+    tail
+
+deps =
+    {[base]deps}
+    requests
+    honcho
+    -e .
+
+commands =
+    python pyserv/settings.py
+    httpdaemon start
+    bash -c 'sleep 1'
+    python tests/check_daemon.py
+    tail -n {env:TAIL} httpd.log
+
+commands_post =
+    httpdaemon stop
+
 [testenv:docs]
 skip_install = true
 allowlist_externals =
@@ -104,16 +141,35 @@ commands =
 skip_install = true
 allowlist_externals =
     bash
+    tail
 
-passenv = CI
+setenv =
+    DEBUG = {env:DEBUG:1}
+    LOGFILE = {env:LOGFILE:{envlogdir}/httpd.log}
+    PIDFILE = {env:PIDFILE:{envtmpdir}/httpd.pid}
+    TAIL = {env:TAIL:1}
+
+passenv =
+    CI
+    GITHUB*
+    PIP_DOWNLOAD_CACHE
 
 deps =
     pip>=21.1
+    requests
 
 commands =
     pip install pyserv --force-reinstall --pre --prefer-binary -f dist/
-    bash -c 'which httpdaemon'
+    python -c "from pyserv.settings import show_uservars; show_uservars()"
+    httpdaemon start -P{env:PIDFILE} -L{env:LOGFILE}
+    bash -c 'sleep 2'
+    httpdaemon status
+    python tests/check_daemon.py
+    bash -c 'sleep 1'
+    tail -n {env:TAIL} {env:LOGFILE}
 
+commands_post =
+    httpdaemon stop
 
 [testenv:lint]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,6 @@ deps =
 [testenv]
 skip_install = true
 
-setenv =
-    LOG = {env:LOG:{envlogdir}/httpd.log}
-    PID = {env:PID:{envtmpdir}/httpd.pid}
-
 passenv =
     DISPLAY
     XAUTHORITY
@@ -57,7 +53,6 @@ deps =
     -e .[test,cov]
 
 commands =
-    python -c "from pyserv.settings import show_uservars; print(show_uservars())"
     pytest -v --capture=fd . --cov=pyserv --cov-branch --cov-report term-missing pyserv/
     coverage xml
     bash -c './.github/fix_pkg_name.sh'
@@ -90,7 +85,9 @@ deps =
     -e .
 
 commands =
-    python -c "from pyserv.settings import show_uservars; print(show_uservars())"
+    python -c 'from pyserv.settings import show_uservars; show_uservars()'
+    httpdaemon --version
+    httpdaemon -h
     httpdaemon start
     bash -c 'sleep 1'
     python tests/check_daemon.py
@@ -142,9 +139,6 @@ skip_install = true
 allowlist_externals =
     bash
 
-setenv =
-    DEBUG = {env:DEBUG:1}
-
 passenv =
     CI
     GITHUB*
@@ -157,6 +151,7 @@ deps =
 commands =
     pip install pyserv --force-reinstall --pre --prefer-binary -f dist/
     python -c "from pyserv import server; print(server.__doc__)"
+    python -c 'from pyserv.settings import show_uservars; show_uservars()'
 
 [testenv:lint]
 passenv =


### PR DESCRIPTION
* parse args with argparse => start, stop, etc, adds version and help output
* pass docroot to http handler
* tox file and lint cleanup

Closes: issue #8