### PR TITLE
make install compatible with ubuntu LTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # daemon requirements, useful for tox/pip
 -f https://github.com/sarnold/python-daemonizer/releases/
-daemonizer>=0.3.4; sys.platform!="win32"
+daemonizer>=0.3.4; platform_system!="Windows"
 appdirs

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ keywords =
 python_requires = >= 3.7
 install_requires =
     appdirs
-    daemonizer @ git+https://github.com/sarnold/python-daemonizer.git ; sys_platform!='Windows'
+    daemonizer @ git+https://github.com/sarnold/python-daemonizer.git@0.3.5#5f6bc3c80a90344b2c8e4cc24ed0b8c098a7af50
 
 packages = find:
 zip_safe = True

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ passenv =
     PYTHONIOENCODING
     PIP_DOWNLOAD_CACHE
 
-allowlist_externals =
+whitelist_externals =
     bash
 
 deps =
@@ -74,7 +74,7 @@ passenv =
     PYTHONIOENCODING
     PIP_DOWNLOAD_CACHE
 
-allowlist_externals =
+whitelist_externals =
     bash
     tail
 
@@ -99,7 +99,7 @@ commands_post =
 
 [testenv:docs]
 skip_install = true
-allowlist_externals =
+whitelist_externals =
     make
 
 deps =
@@ -110,7 +110,7 @@ commands = make -C docs html
 
 [testenv:docs-lint]
 skip_install = true
-allowlist_externals =
+whitelist_externals =
     make
 
 deps =
@@ -137,7 +137,7 @@ commands =
 
 [testenv:check]
 skip_install = true
-allowlist_externals =
+whitelist_externals =
     bash
 
 passenv =
@@ -214,7 +214,7 @@ commands =
 
 [testenv:clean]
 skip_install = true
-allowlist_externals =
+whitelist_externals =
     bash
 
 deps =


### PR DESCRIPTION
* remove environment marker from daemonizer dep in setup.cgf, use PEP440 url
* sadly this is required for "stock" Ubuntu focal since it does not appear to understand PEP345 markers
* this means we have to rely on readme blurb about posix daemon not compatible with Windows

Closes: issue #12 