### PR TITLE
Status fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -519,7 +519,7 @@ specifications.
     :target: https://github.com/sarnold/pyserv/actions/workflows/pylint.yml
     :alt: Pylint Status
 
-.. |release| image:: https://github.com/sarnold/pyserv/actions/workflows/release.yml/badge.svg
+.. |release| image:: https://github.com/sarnold/pyserv/actions/workflows/release.yml/badge.svg?event=push
     :target: https://github.com/sarnold/pyserv/actions/workflows/release.yml
     :alt: Release Status
 


### PR DESCRIPTION
* use push event for current release status

Somehow adding workflow_dispatch made github look away and start displaying the wrong status (where push event is now correct).