### PR TITLE
cleanup version lint

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -260,7 +260,7 @@ include_merge = False
 ##        take care of everything and might be more complex. Check the README
 ##        for a complete copy-pastable example.
 ##
-# publish = FileInsertIntoFirstRegexMatch(
+# publish = FileInsertAtFirstRegexMatch(
 #     "CHANGELOG.rst",
 #     r'/(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n/',
 #     idx=lambda m: m.start(1)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,8 +12,10 @@
 #
 import os
 import sys
+import subprocess as sp
 
 from datetime import datetime
+from shlex import split
 
 import sphinx_nefertiti
 
@@ -24,28 +26,30 @@ else:
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
-# -- Project information -----------------------------------------------------
 
-# The full version, including alpha/beta/rc tags with setuptols-scm
-# workaround for extra-long dirty version string
-#release = version('pyserv').split("+")[0]
-# screw the short X.Y version.
-#version = release
+def get_current_tag():
+    """
+    Get the current (non-dev) tag value from git.
+    """
+    git_tag_str = "git describe --abbrev=0 --tags"
+    return sp.check_output(split(git_tag_str), text=True).strip()
+
+
+def get_previous_tag():
+    """
+    Get the previous (non-dev) tag value from git.
+    """
+    git_tag_str = "git tag --sort=taggerdate"
+    return sp.check_output(split(git_tag_str), text=True).splitlines()[-2]
+
+
+# -- Project information -----------------------------------------------------
 
 project = 'pyserv'
 author = 'Stephen Arnold'
 copyright = '2022 - ' + str(datetime.now().year) + f' {author}'
 
 # -- General configuration ------------------------------------------------
-
-# If your documentation needs a minimal Sphinx version, state it here.
-#
-# needs_sphinx = '1.0'
-#needs_sphinx = "8.2.0"
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 
 _ver_list = version('pyserv').split(".")
 
@@ -54,7 +58,10 @@ version = ".".join(_ver_list[:2])
 # The X.Y.Z number.
 release = ".".join(_ver_list[:3])
 
-# -- General configuration ---------------------------------------------------
+_ver_last = get_current_tag()
+if _ver_last == release:
+    _ver_last = get_previous_tag()
+
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
@@ -131,7 +138,8 @@ html_theme_options = {
 
     "current_version": "latest",
     "versions": [
-        (f"{release}", f"https://sarnold.github.io/{project}/"),
+        (f"v{release}", f"https://sarnold.github.io/{project}/"),
+        (f"v{_ver_last}", f"https://sarnold.github.io/{project}/"),
     ],
 
     "show_colorset_choices": True,


### PR DESCRIPTION
* make sphinx config use git to get last non-dev versions
* this should work as long as at least 2 tags exist