### PR TITLE
Fallback values for empty defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,30 +111,38 @@ variables, and the following "extra" features:
 
 Sample environment display with tox overrides, ie, inside a Tox_ venv::
 
-  Python version: 3.11.4 (main, Jul  5 2023, 16:15:04) [GCC 12.3.1 20230526]
+  Python version: 3.13.3 (main, Jun  2 2025, 19:32:29) [GCC 15.1.0]
   -------------------------------------------------------------------------------
-  pyserv 1.4.1.dev1
+  pyserv 1.8.4
 
   Pyserv default settings for server and daemon modes.
 
   Default user vars:
     log_dir: /home/user/.local/state/pyserv/log
     pid_dir: /run/user/1001/pyserv
-    work_dir: /home/user/src/pyserv
+    work_dir: /home/user/src/python-servers
 
   Current environment values:
     DEBUG: 1
     PORT: 8000
+    IDEV: lo
     IFACE: 127.0.0.1
     LPNAME: httpd
-    LOG: /home/user/src/pyserv/.tox/dev/log/httpd.log
-    PID: /home/user/src/pyserv/.tox/dev/tmp/httpd.pid
-    DOCROOT: /home/user/src/pyserv
+    LOG: /home/user/src/python-servers/.tox/dev/log/httpd.log
+    PID: /home/user/src/python-servers/.tox/dev/tmp/httpd.pid
+    DOCROOT: /home/user/src/python-servers
     SOCK_TIMEOUT: 5
   -------------------------------------------------------------------------------
 
-Use any of the variables under "Current environment values" to set your
-own custom environment.
+Use, ie, export any of the variables under "Current environment values"
+to set your own custom environment settings.
+
+.. important:: The ``os.getenv`` defaults are only applied if the corresponding
+               environment variable *is not set*. Previously it was possible
+               to set the above environment vars *to an empty value* but this
+               is no longer the case. From this release onward, empty values
+               are ignored and the default value is applied instead.
+
 
 Daemon usage
 ------------

--- a/requirements-rpm.txt
+++ b/requirements-rpm.txt
@@ -6,3 +6,5 @@ git+https://github.com/msoulier/tftpy.git@8b84f45#egg=tftpy
 git+https://github.com/sarnold/picotui.git@ef69442#egg=picotui
 # version 0.14.0.1
 git+https://github.com/VCTLabs/pygtail.git@7026c3a#egg=pygtail
+# version 1.3.0
+py3tftp  # async daemon requirement

--- a/src/pyserv/settings.py
+++ b/src/pyserv/settings.py
@@ -92,12 +92,19 @@ def show_uservars():
         print(f"FAILED: {repr(exc)}")
 
 
-DEBUG = os.getenv('DEBUG', default='0')
-PORT = os.getenv('PORT', default='8000')
-IDEV = os.getenv('IDEV', default='lo')
-IFACE = os.getenv('IFACE', default='127.0.0.1')
-LPNAME = os.getenv('LPNAME', default='httpd')
-LOG = os.getenv('LOG', default=str(get_userdirs()[0].joinpath(f'{LPNAME}.log')))
-PID = os.getenv('PID', default=str(get_userdirs()[1].joinpath(f'{LPNAME}.pid')))
-DOCROOT = os.getenv('DOCROOT', default=str(get_userdirs()[2]))
-SOCK_TIMEOUT = os.getenv('SOCK_TIMEOUT', default='5')
+DEBUG = os.getenv('DEBUG', default='0') or '0'
+PORT = os.getenv('PORT', default='8000') or '8000'
+IDEV = os.getenv('IDEV', default='lo') or 'lo'
+IFACE = os.getenv('IFACE', default='127.0.0.1') or '127.0.0.1'
+LPNAME = os.getenv('LPNAME', default='httpd') or 'httpd'
+SOCK_TIMEOUT = os.getenv('SOCK_TIMEOUT', default='5') or '5'
+# fmt: stop
+LOG = os.getenv('LOG', default=str(get_userdirs()[0].joinpath(f'{LPNAME}.log'))) or str(
+    get_userdirs()[0].joinpath(f'{LPNAME}.log')
+)  # noqa
+PID = os.getenv('PID', default=str(get_userdirs()[1].joinpath(f'{LPNAME}.pid'))) or str(
+    get_userdirs()[1].joinpath(f'{LPNAME}.pid')
+)  # noqa
+DOCROOT = os.getenv('DOCROOT', default=str(get_userdirs()[2])) or str(
+    get_userdirs()[2]
+)  # noqa

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -18,6 +18,53 @@ from pyserv.settings import (
 WIN32 = sys.platform == 'win32'
 APPLE = sys.platform == 'darwin'
 
+EXPECTED = {
+    "DEBUG": '0',
+    "PORT": '8000',
+    "IDEV": 'lo',
+    "IFACE": '127.0.0.1',
+    "LPNAME": 'httpd',
+    "SOCK_TIMEOUT": '5',
+    "LOG": str(get_userdirs()[0].joinpath('httpd.log')),
+    "PID": str(get_userdirs()[1].joinpath('httpd.pid')),
+    "DOCROOT": str(get_userdirs()[2]),
+}
+EMPTY = {
+    "DEBUG": '',
+    "PORT": '',
+    "IDEV": '',
+    "IFACE": '',
+    "LPNAME": '',
+    "SOCK_TIMEOUT": '',
+    "LOG": '',
+    "PID": '',
+    "DOCROOT": '',
+}
+
+
+def test_settings_not_empty(monkeypatch):
+    for k in EMPTY:
+        monkeypatch.setenv(k, "")
+        assert EMPTY[k] == ""
+
+    from pyserv.settings import (
+        DEBUG,
+        DOCROOT,
+        IDEV,
+        IFACE,
+        LOG,
+        LPNAME,
+        PID,
+        PORT,
+        SOCK_TIMEOUT,
+    )
+
+    for key, envar in zip(
+        EXPECTED, (DEBUG, PORT, IDEV, IFACE, LPNAME, SOCK_TIMEOUT, LOG, PID, DOCROOT)
+    ):
+        assert envar == EXPECTED[key]
+        print(envar)
+
 
 def test_get_userdirs():
     """We should get Path objs"""
@@ -70,4 +117,5 @@ def test_show_uservars_error(monkeypatch, capfd):
     monkeypatch.delattr('pyserv.settings.LOG', raising=True)
     show_uservars()
     out, err = capfd.readouterr()
+    print(out)
     assert "FAILED:" in out

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,9 @@ depends =
 
 [coverage:run]
 parallel=True
+omit =
+    */tests/*
+    */_version.py
 
 [testenv:dev]
 envdir = {toxinidir}/.venv


### PR DESCRIPTION
* add fallback values for empty environment settings
* provide the same default values for each setting var if set but empty
* add another test using monkeypatched empty values
* update requirements file and coverage config

this closes issue #62